### PR TITLE
updating class/method references to reflect open3d 0.8 module structure

### DIFF
--- a/probreg/cpd.py
+++ b/probreg/cpd.py
@@ -221,7 +221,7 @@ def registration_cpd(source, target, tf_type_name='rigid',
         callback (:obj:`list` of :obj:`function`, optional): Called after each iteration.
             `callback(probreg.Transformation)`
     """
-    cv = lambda x: np.asarray(x.points if isinstance(x, o3.PointCloud) else x)
+    cv = lambda x: np.asarray(x.points if isinstance(x, o3.geometry.PointCloud) else x)
     if tf_type_name == 'rigid':
         cpd = RigidCPD(cv(source), **kargs)
     elif tf_type_name == 'affine':

--- a/probreg/features.py
+++ b/probreg/features.py
@@ -40,9 +40,9 @@ class FPFH(Feature):
         pass
 
     def compute(self, data):
-        pcd = o3.PointCloud()
-        pcd.points = o3.Vector3dVector(data)
-        o3.estimate_normals(pcd, self._param_normal)
+        pcd = o3.geometry.PointCloud()
+        pcd.points = o3.utility.Vector3dVector(data)
+        pcd.estimate_normals(search_param=self._param_normal)
         fpfh = o3.registration.compute_fpfh_feature(pcd, self._param_feature)
         return fpfh.data.T
 

--- a/probreg/filterreg.py
+++ b/probreg/filterreg.py
@@ -181,7 +181,7 @@ def registration_filterreg(source, target, target_normals=None,
         callback (:obj:`list` of :obj:`function`, optional): Called after each iteration.
             `callback(probreg.Transformation)`
     """
-    cv = lambda x: np.asarray(x.points if isinstance(x, o3.PointCloud) else x)
+    cv = lambda x: np.asarray(x.points if isinstance(x, o3.geometry.PointCloud) else x)
     frg = RigidFilterReg(cv(source), cv(target_normals), sigma2, **kargs)
     frg.set_callbacks(callbacks)
     return frg.registration(cv(target), objective_type=objective_type, maxiter=maxiter,

--- a/probreg/gmmtree.py
+++ b/probreg/gmmtree.py
@@ -81,7 +81,7 @@ class GMMTree():
 
 def registration_gmmtree(source, target, maxiter=20, tol=1.0e-4,
                          callbacks=[], **kargs):
-    cv = lambda x: np.asarray(x.points if isinstance(x, o3.PointCloud) else x)
+    cv = lambda x: np.asarray(x.points if isinstance(x, o3.geometry.PointCloud) else x)
     gt = GMMTree(cv(source), **kargs)
     gt.set_callbacks(callbacks)
     return gt.registration(cv(target), maxiter, tol)

--- a/probreg/l2dist_regs.py
+++ b/probreg/l2dist_regs.py
@@ -144,7 +144,7 @@ class TPSSVR(L2DistRegistration):
 
 def registration_gmmreg(source, target, tf_type_name='rigid',
                         callbacks=[], **kargs):
-    cv = lambda x: np.asarray(x.points if isinstance(x, o3.PointCloud) else x)
+    cv = lambda x: np.asarray(x.points if isinstance(x, o3.geometry.PointCloud) else x)
     if tf_type_name == 'rigid':
         gmmreg = RigidGMMReg(cv(source), **kargs)
     elif tf_type_name == 'nonrigid':
@@ -159,7 +159,7 @@ def registration_svr(source, target, tf_type_name='rigid',
                      maxiter=1, tol=1.0e-3,
                      opt_maxiter=50, opt_tol=1.0e-3,
                      callbacks=[], **kargs):
-    cv = lambda x: np.asarray(x.points if isinstance(x, o3.PointCloud) else x)
+    cv = lambda x: np.asarray(x.points if isinstance(x, o3.geometry.PointCloud) else x)
     if tf_type_name == 'rigid':
         svr = RigidSVR(cv(source), **kargs)
     elif tf_type_name == 'nonrigid':

--- a/probreg/transformation.py
+++ b/probreg/transformation.py
@@ -11,7 +11,7 @@ class Transformation():
         pass
 
     def transform(self, points,
-                  array_type=o3.Vector3dVector):
+                  array_type=o3.utility.Vector3dVector):
         if isinstance(points, array_type):
             return array_type(self._transform(np.asarray(points)))
         return self._transform(points)


### PR DESCRIPTION
The routines in here use module paths that don't seem to exist anymore in the open3d 0.8 release.  This PR updates the paths so that they work.  This just involves using full nested module paths such as `open3d.geometry.PointCloud` instead of top level references like `open3d.PointCloud` which don't seem to exist anymore.  I believe that means it should retain compatibility with version 0.7.