### PR TITLE
replace namedtuple instead of modifying immutable attribute

### DIFF
--- a/probreg/filterreg.py
+++ b/probreg/filterreg.py
@@ -128,7 +128,7 @@ class FilterReg():
                                               objective_type)
             res = self.maximization_step(t_source, target, estep_res, w=w, objective_type=objective_type)
             if res.q is None:
-                res.q = q
+                res = res._replace(q=q)
                 break
             self._tf_result = res.transformation
             self._sigma2 = max(res.sigma2, min_sigma2)


### PR DESCRIPTION
It seems that namedtuples are immutable in python, that's why I got a 'AttributeError: can't set attribute' when trying to assign q. Using the _replace method to create a new instance with that entry replaced solves it for me. Python 3.7.3. See [this link](https://stackoverflow.com/questions/22562425/attributeerror-cant-set-attribute-in-python).