### PR TITLE
Fix BCPD convergence issues and align with the original C implementation

### DIFF
--- a/probreg/bcpd.py
+++ b/probreg/bcpd.py
@@ -59,7 +59,6 @@ class BayesianCoherentPointDrift:
         pmat /= (2.0 * np.pi * sigma2) ** (dim * 0.5)
         pmat = pmat.T
         pmat *= (1.0 - w) * alpha
-        # Outlier term: uniform distribution over bounding box volume (matching C code)
         bb_range = target.max(axis=0) - target.min(axis=0)
         bb_range = np.maximum(bb_range, 1e-10)
         volume = np.prod(bb_range)

--- a/probreg/bcpd.py
+++ b/probreg/bcpd.py
@@ -58,14 +58,19 @@ class BayesianCoherentPointDrift:
         pmat = np.exp(-pmat / (2.0 * sigma2))
         pmat /= (2.0 * np.pi * sigma2) ** (dim * 0.5)
         pmat = pmat.T
-        pmat *= np.exp(-(scale**2) / (2 * sigma2) * np.diag(sigma_mat) * dim)
         pmat *= (1.0 - w) * alpha
-        den = w / target.shape[0] + np.sum(pmat, axis=1)
+        # Outlier term: uniform distribution over bounding box volume (matching C code)
+        bb_range = target.max(axis=0) - target.min(axis=0)
+        bb_range = np.maximum(bb_range, 1e-10)
+        volume = np.prod(bb_range)
+        outlier_term = w / volume
+        den = outlier_term + np.sum(pmat, axis=1)
         den[den == 0] = np.finfo(np.float32).eps
         pmat = np.divide(pmat.T, den)
 
         nu_d = np.sum(pmat, axis=0)
         nu = np.sum(pmat, axis=1)
+        nu = np.maximum(nu, 1e-20)
         nu_inv = 1.0 / np.kron(nu, np.ones(dim))
         px = np.dot(np.kron(pmat, np.identity(dim)), target.ravel())
         x_hat = np.multiply(px, nu_inv).reshape(-1, dim)
@@ -101,18 +106,25 @@ class BayesianCoherentPointDrift:
 
 
 class CombinedBCPD(BayesianCoherentPointDrift):
-    def __init__(self, source=None, lmd=2.0, k=1.0e20, gamma=1.0):
+    def __init__(self, source=None, lmd=2.0, k=1.0e20, gamma=1.0, beta=1.0, kernel="imq"):
         super(CombinedBCPD, self).__init__(source)
         self._tf_type = tf.CombinedTransformation
         self.lmd = lmd
         self.k = k
         self.gamma = gamma
+        self.beta = beta
+        self.kernel = kernel
 
     def _initialize(self, target):
         m, dim = self._source.shape
-        self.gmat = mu.inverse_multiquadric_kernel(self._source, self._source)
+        if self.kernel == "imq":
+            self.gmat = mu.inverse_multiquadric_kernel(self._source, self._source, self.beta)
+        elif self.kernel == "rbf":
+            self.gmat = mu.rbf_kernel(self._source, self._source, self.beta)
+        else:
+            raise ValueError("Invalid kernel type: %s" % self.kernel)
         self.gmat_inv = np.linalg.inv(self.gmat)
-        sigma2 = self.gamma * mu.squared_kernel_sum(self._source, target)
+        sigma2 = (self.gamma ** 2) * mu.squared_kernel_sum(self._source, target)
         q = 1.0 + target.shape[0] * dim * 0.5 * np.log(sigma2)
         return MstepResult(self._tf_type(np.identity(dim), np.zeros(dim)), None, np.identity(m), 1.0 / m, sigma2)
 
@@ -126,7 +138,7 @@ class CombinedBCPD(BayesianCoherentPointDrift):
         nu_d, nu, n_p, px, x_hat = estep_res
         dim = source.shape[1]
         m = source.shape[0]
-        s2s2 = rigid_trans.scale**2 / (sigma2_p**2)
+        s2s2 = rigid_trans.scale**2 / sigma2_p
         sigma_mat_inv = lmd * gmat_inv + s2s2 * np.diag(nu)
         sigma_mat = np.linalg.inv(sigma_mat_inv)
         residual = rigid_trans.inverse().transform(x_hat) - source
@@ -140,19 +152,20 @@ class CombinedBCPD(BayesianCoherentPointDrift):
         u_m = np.sum(nu * u_hat.T, axis=1) / n_p
         u_hm = u_hat - u_m
         s_xu = np.matmul(np.multiply(nu, (x_hat - x_m).T), u_hm) / n_p
-        s_uu = np.matmul(np.multiply(nu, u_hm.T), u_hm) / n_p + sigma2_m * np.identity(dim)
+        s_uu = np.matmul(np.multiply(nu, u_hm.T), u_hm) / n_p
         phi, _, psih = np.linalg.svd(s_xu, full_matrices=True)
         c = np.ones(dim)
         c[-1] = np.linalg.det(np.dot(phi, psih))
         rot = np.matmul(phi * c, psih)
-        tr_rsxu = np.trace(np.matmul(rot, s_xu))
+        tr_rsxu = np.sum(rot * s_xu)
         scale = tr_rsxu / np.trace(s_uu)
         t = x_m - scale * np.dot(rot, u_m)
-        y_hat = rigid_trans.transform(source + v_hat)
+        y_hat = scale * np.dot(u_hat, rot.T) + t
         s1 = np.dot(target.ravel(), np.kron(nu_d, np.ones(dim)) * target.ravel())
         s2 = np.dot(px.ravel(), y_hat.ravel())
         s3 = np.dot(y_hat.ravel(), np.kron(nu, np.ones(dim)) * y_hat.ravel())
-        sigma2 = (s1 - 2.0 * s2 + s3) / (n_p * dim) + scale**2 * sigma2_m
+        sigma2 = (s1 - 2.0 * s2 + s3) / (n_p * dim)
+        sigma2 = max(abs(sigma2), np.finfo(np.float64).eps)
         return MstepResult(tf.CombinedTransformation(rot, t, scale, v_hat), u_hat, sigma_mat, alpha, sigma2)
 
 

--- a/probreg/bcpd.py
+++ b/probreg/bcpd.py
@@ -35,8 +35,9 @@ class BayesianCoherentPointDrift:
         source (numpy.ndarray, optional): Source point cloud data.
     """
 
-    def __init__(self, source=None):
+    def __init__(self, source=None, use_debias=False):
         self._source = source
+        self._use_debias = use_debias
         self._tf_type = None
         self._callbacks = []
 
@@ -58,6 +59,8 @@ class BayesianCoherentPointDrift:
         pmat = np.exp(-pmat / (2.0 * sigma2))
         pmat /= (2.0 * np.pi * sigma2) ** (dim * 0.5)
         pmat = pmat.T
+        if self._use_debias and sigma_mat is not None:
+            pmat *= np.exp(-(scale**2) / (2 * sigma2) * np.diag(sigma_mat) * dim)
         pmat *= (1.0 - w) * alpha
         bb_range = target.max(axis=0) - target.min(axis=0)
         bb_range = np.maximum(bb_range, 1e-10)
@@ -105,8 +108,8 @@ class BayesianCoherentPointDrift:
 
 
 class CombinedBCPD(BayesianCoherentPointDrift):
-    def __init__(self, source=None, lmd=2.0, k=1.0e20, gamma=1.0, beta=1.0, kernel="imq"):
-        super(CombinedBCPD, self).__init__(source)
+    def __init__(self, source=None, lmd=2.0, k=1.0e20, gamma=1.0, beta=1.0, kernel="imq", use_debias=False):
+        super(CombinedBCPD, self).__init__(source, use_debias)
         self._tf_type = tf.CombinedTransformation
         self.lmd = lmd
         self.k = k
@@ -129,11 +132,11 @@ class CombinedBCPD(BayesianCoherentPointDrift):
 
     def maximization_step(self, target, rigid_trans, estep_res, sigma2_p=None):
         return self._maximization_step(
-            self._source, target, rigid_trans, estep_res, self.gmat_inv, self.lmd, self.k, sigma2_p
+            self._source, target, rigid_trans, estep_res, self.gmat_inv, self.lmd, self.k, sigma2_p, self._use_debias
         )
 
     @staticmethod
-    def _maximization_step(source, target, rigid_trans, estep_res, gmat_inv, lmd, k, sigma2_p=None):
+    def _maximization_step(source, target, rigid_trans, estep_res, gmat_inv, lmd, k, sigma2_p=None, use_debias=False):
         nu_d, nu, n_p, px, x_hat = estep_res
         dim = source.shape[1]
         m = source.shape[0]
@@ -152,6 +155,8 @@ class CombinedBCPD(BayesianCoherentPointDrift):
         u_hm = u_hat - u_m
         s_xu = np.matmul(np.multiply(nu, (x_hat - x_m).T), u_hm) / n_p
         s_uu = np.matmul(np.multiply(nu, u_hm.T), u_hm) / n_p
+        if use_debias:
+            s_uu += sigma2_m * np.identity(dim)
         phi, _, psih = np.linalg.svd(s_xu, full_matrices=True)
         c = np.ones(dim)
         c[-1] = np.linalg.det(np.dot(phi, psih))
@@ -164,6 +169,8 @@ class CombinedBCPD(BayesianCoherentPointDrift):
         s2 = np.dot(px.ravel(), y_hat.ravel())
         s3 = np.dot(y_hat.ravel(), np.kron(nu, np.ones(dim)) * y_hat.ravel())
         sigma2 = (s1 - 2.0 * s2 + s3) / (n_p * dim)
+        if use_debias:
+            sigma2 += rigid_trans.scale**2 * sigma2_m
         sigma2 = max(abs(sigma2), np.finfo(np.float64).eps)
         return MstepResult(tf.CombinedTransformation(rot, t, scale, v_hat), u_hat, sigma_mat, alpha, sigma2)
 


### PR DESCRIPTION
## Summary
This PR fixes significant convergence [issues](https://github.com/neka-nat/probreg/issues/59) in the BCPD (Bayesian Coherent Point Drift) implementation. By comparing the logic with the original C implementation ([ohirose/bcpd](https://github.com/ohirose/bcpd)), several mathematical and implementation-level discrepancies were identified and corrected. These fixes enable BCPD to achieve the same level of accuracy and stability as the original implementation, especially when using extreme regularization parameters (e.g., "rigid-hack" settings).

## Key Bug Fixes and Improvements

### 1. Corrected Frobenius Inner Product for Scale Update
- In the M-step, the scale update logic previously used a simplified trace calculation that was mathematically inconsistent with the Procrustes analysis. It has been corrected to use the Frobenius inner product (`np.sum(rot * s_xu)`), matching exactly with the index-summation in the C code [L365-367](https://github.com/ohirose/bcpd/blob/master/register/bcpd.c?#L365).

### 2. Updated Transformation Usage in Variance Calculation
- The residual variance ($\sigma^2$) was previously being updated using the transformation parameters from the *previous* iteration. This led to stalled convergence. The logic now re-calculates `y_hat` using the latest `R, s, t` before updating $\sigma^2$, as seen in the original implementation's update order [L373-382](https://github.com/ohirose/bcpd/blob/master/register/bcpd.c?#L373).

### 3. Outlier Probability Normalization
- The outlier term has been changed from `w / N` to `w / volume` (where volume is the bounding box of the target). This aligns with the probability density of a uniform distribution over the target space, preventing bias across different data scales. [L265](https://github.com/ohirose/bcpd/blob/master/register/bcpd.c?#L265).

### 4. Initialization and Scaling Fixes
- Corrected the initial $\sigma^2$ calculation to use $\gamma^2$ scaling, ensuring consistency with the standard deviation definition in the original paper and C implementation [L251](https://github.com/ohirose/bcpd/blob/master/register/bcpd.c#L251).
- Fixed a bug where `sigma2` was squared again in the `s2s2` ratio calculation, which severely decoupled $\lambda$ and $\sigma^2$ as they approached zero.

### 5. Optionalized Debias Terms
- Certain debias/correction terms were being applied constantly. In the original C implementation, these are only enabled with the `-a` flag (aliased as `db` in the source). They are now disabled by default to match the standard behavior, significantly improving initial convergence speed. [L179, L331, L364, L377](https://github.com/ohirose/bcpd/blob/master/register/bcpd.c#L179).

## Verification
Tested using the Stanford Bunny dataset (`bunny.pcd`) with 500 outliers and a 30-degree rotation.

| Metric | Previous implementation | This PR | Original C Implementation |
| :--- | :--- | :--- | :--- |
| **RMSE (Final)** | 0.012900 | **0.003600** | **0.003603** |
| **Convergence** | Stalled / Poor | **Success** | **Success** |

The results show that the Python implementation now matches the original C implementation's performance within 0.1% accuracy.

```
def compute_mse(source_file, target_file):
    source = np.loadtxt(source_file)
    target = np.loadtxt(target_file)
    tree = cKDTree(target)
    dist, _ = tree.query(source)
    return np.mean(dist**2)

print("\n--- Test : C code params (lmd=1e10, k=1e80, gamma=0.5) ---")
tf_result = bcpd.registration_bcpd(source, target, w=0.1, lmd=1e10, k=1e80, gamma=0.5, maxiter=100, tol=1e-9, beta=1.0, kernel='imq')
target_estimated = tf_result.transform(source)
rmse = compute_rmse(target_estimated, target)
print(f"RMSE (C params, IMQ): {rmse:.6f}")
print(f"  scale={tf_result.rigid_trans.scale:.6f}")
```